### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dag_deployment_dev-int.yml
+++ b/.github/workflows/dag_deployment_dev-int.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: DAG image creation and airflow deployment
         if: always()
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DEV_RELEASE_NAME }}/airflow:deploy-ci-${{ github.run_number }}
           username: _

--- a/.github/workflows/dag_deployment_prod.yml
+++ b/.github/workflows/dag_deployment_prod.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: DAG image creation and airflow deployment
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.PROD_RELEASE_NAME }}/airflow:deploy-ci-${{ github.run_number }}
           username: _

--- a/.github/workflows/dag_deployment_stg.yml
+++ b/.github/workflows/dag_deployment_stg.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.G_TOKEN }}
          
       - name: DAG image creation and airflow deployment
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.STG_RELEASE_NAME }}/airflow:deploy-ci-${{ github.run_number }}
           username: _


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore